### PR TITLE
Fix chevronright rotate

### DIFF
--- a/src/modules/cmp/relationshipsTree/relationshipsTree.html
+++ b/src/modules/cmp/relationshipsTree/relationshipsTree.html
@@ -3,7 +3,13 @@
   <ul class="slds-tree" if:false={isNoRelationships}>
     <template for:each={relationships} for:item="relation">
       <template if:true={relation.relationshipName}>
-        <li aria-level="1" aria-selected={relation.isActive} role="treeitem" key={relation.relationshipName}>
+        <li
+          aria-level="1"
+          aria-selected={relation.isActive}
+          aria-expanded={relation.isExpanded}
+          role="treeitem"
+          key={relation.relationshipName}
+        >
           <div class="slds-tree__item">
             <button
               class="slds-button slds-button_icon slds-m-right_x-small"


### PR DESCRIPTION
Fixed a problem in which icons did not rotate when expanding a reference item in the Relations tree.

<img width="340" alt="image" src="https://user-images.githubusercontent.com/41602570/158952084-6ff7ad02-66af-4e9f-8f10-a5adbb3f9750.png">
