### PR TITLE
Add syntax code completion.

### DIFF
--- a/src/modules/cmp/queryEditorPanel/queryEditorPanel.html
+++ b/src/modules/cmp/queryEditorPanel/queryEditorPanel.html
@@ -17,16 +17,16 @@
     <div class="completion-popover slds-popover" style={completionStyle} if:true={isCompletionVisible}>
       <ul class="slds-listbox slds-listbox_vertical" role="presentation">
         <template for:each={completionFields} for:item="field">
-          <li role="presentation" class="slds-listbox__item" key={field.name}>
+          <li role="presentation" class="slds-listbox__item" key={field.key}>
             <div
               class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
               aria-selected={field.isActive}
               role="option"
             >
               <span class="slds-media__body">
-                <span class="slds-truncate" title={field.itemLabel} data-name={field.name} onclick={insertField}
-                  >{field.itemLabel}</span
-                >
+                <span class="slds-truncate" title={field.itemLabel} data-key={field.key} onclick={insertField}>
+                  {field.itemLabel}
+                </span>
               </span>
             </div>
           </li>

--- a/src/modules/cmp/queryEditorPanel/queryEditorPanel.html
+++ b/src/modules/cmp/queryEditorPanel/queryEditorPanel.html
@@ -23,7 +23,23 @@
               aria-selected={field.isActive}
               role="option"
             >
-              <span class="slds-media__body">
+              <span class="slds-icon_container slds-icon-utility-text" if:false={field.isSyntax}>
+                <svg
+                  class="slds-icon slds-icon_x-small slds-input__icon_left slds-icon-text-default"
+                  aria-hidden="true"
+                >
+                  <use xlink:href="./resources/slds/icons/utility-sprite/svg/symbols.svg#text"></use>
+                </svg>
+              </span>
+              <span class="slds-icon_container slds-icon-utility-display_text" if:true={field.isSyntax}>
+                <svg
+                  class="slds-icon slds-icon_x-small slds-input__icon_left slds-icon-text-default"
+                  aria-hidden="true"
+                >
+                  <use xlink:href="./resources/slds/icons/utility-sprite/svg/symbols.svg#display_text"></use>
+                </svg>
+              </span>
+              <span class="slds-media__body slds-m-left_x-small">
                 <span class="slds-truncate" title={field.itemLabel} data-key={field.key} onclick={insertField}>
                   {field.itemLabel}
                 </span>

--- a/src/modules/cmp/queryEditorPanel/queryEditorPanel.js
+++ b/src/modules/cmp/queryEditorPanel/queryEditorPanel.js
@@ -72,14 +72,12 @@ export default class QueryEditorPanel extends I18nMixin(LightningElement) {
 
     insertField(event) {
         const key = event.target.dataset.key;
-        console.log('insertField', key);
         if (this._closeCompletionTimer) {
             clearTimeout(this._closeCompletionTimer);
         }
         const selectedField = this.completionFields.find(
             field => field.key === key
         );
-        console.log('selectedField', selectedField);
         const inputEl = this.template.querySelector('.soql-input');
         this._insertField(inputEl, selectedField);
     }
@@ -188,9 +186,6 @@ export default class QueryEditorPanel extends I18nMixin(LightningElement) {
         );
         const escapedKeyword = escapeRegExp(keyword);
         const keywordPattern = new RegExp(escapedKeyword, 'i');
-        console.log('escapedKeyword', escapedKeyword);
-        console.log('keywordPattern', JSON.stringify(keywordPattern));
-
         this.completionFields = this._sobjectMeta.fields
             .filter(field =>
                 keywordPattern.test(`${field.name} ${field.label}`)
@@ -218,7 +213,6 @@ export default class QueryEditorPanel extends I18nMixin(LightningElement) {
         if (syntaxItems.length > 0) {
             this.completionFields = syntaxItems.concat(this.completionFields);
         }
-        console.log('_searchCompletionFields1', this.completionFields.length);
         if (this.completionFields.length > 0) {
             this.completionFields[0].isActive = true;
             this._setCompletionPosition(event);
@@ -226,10 +220,6 @@ export default class QueryEditorPanel extends I18nMixin(LightningElement) {
         } else {
             this.isCompletionVisible = false;
         }
-        console.log(
-            '_searchCompletionFields this.isCompletionVisible1',
-            this.isCompletionVisible
-        );
     }
 
     _handleCompletion(event) {

--- a/src/modules/cmp/queryEditorPanel/queryEditorPanel.js
+++ b/src/modules/cmp/queryEditorPanel/queryEditorPanel.js
@@ -188,6 +188,9 @@ export default class QueryEditorPanel extends I18nMixin(LightningElement) {
         );
         const escapedKeyword = escapeRegExp(keyword);
         const keywordPattern = new RegExp(escapedKeyword, 'i');
+        console.log('escapedKeyword', escapedKeyword);
+        console.log('keywordPattern', JSON.stringify(keywordPattern));
+
         this.completionFields = this._sobjectMeta.fields
             .filter(field =>
                 keywordPattern.test(`${field.name} ${field.label}`)
@@ -215,6 +218,7 @@ export default class QueryEditorPanel extends I18nMixin(LightningElement) {
         if (syntaxItems.length > 0) {
             this.completionFields = syntaxItems.concat(this.completionFields);
         }
+        console.log('_searchCompletionFields1', this.completionFields.length);
         if (this.completionFields.length > 0) {
             this.completionFields[0].isActive = true;
             this._setCompletionPosition(event);
@@ -222,6 +226,10 @@ export default class QueryEditorPanel extends I18nMixin(LightningElement) {
         } else {
             this.isCompletionVisible = false;
         }
+        console.log(
+            '_searchCompletionFields this.isCompletionVisible1',
+            this.isCompletionVisible
+        );
     }
 
     _handleCompletion(event) {


### PR DESCRIPTION
Status: Working

Remaining Tasks

 - syntax Icon Consideration
 - field Icon Consideration
 - Bug with text remaining when inserting.
 - Completion processing for cases containing line feeds


---

Add syntax code completion.(Image icons are tentative)
![image](https://user-images.githubusercontent.com/41602570/158988349-753e9b64-595b-443d-ae63-0835266f1ff5.png)

The supported syntaxes are
```
// src/modules/cmp/queryEditorPanel/queryEditorPanel.js
const SOQL_SYNTAX_WORDS = [
    'SELECT',
    'FROM',
    'WHERE',
    'AND',
    'OR',
    'LIKE',
    'IN',
    'GROUP BY',
    'HAVING',
    'ORDER BY',
    'LIMIT',
    'OFFSET'
];
```
Related Links:
https://developer.salesforce.com/docs/atlas.ja-jp.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select.htm